### PR TITLE
fix UART clock freq for esp32 (AEGHB-309)

### DIFF
--- a/examples/esp-radar/console_test/main/app_main.c
+++ b/examples/esp-radar/console_test/main/app_main.c
@@ -515,7 +515,7 @@ void app_main(void)
     /**< Fix serial port garbled code due to high baud rate */
     uart_ll_set_sclk(UART_LL_GET_HW(CONFIG_ESP_CONSOLE_UART_NUM), UART_SCLK_APB);
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-    uart_ll_set_baudrate(UART_LL_GET_HW(CONFIG_ESP_CONSOLE_UART_NUM), CONFIG_ESP_CONSOLE_UART_BAUDRATE, CONFIG_ESP_CONSOLE_UART_BAUDRATE);
+    uart_ll_set_baudrate(UART_LL_GET_HW(CONFIG_ESP_CONSOLE_UART_NUM), CONFIG_ESP_CONSOLE_UART_BAUDRATE, APB_CLK_FREQ);
 #else
     uart_ll_set_baudrate(UART_LL_GET_HW(CONFIG_ESP_CONSOLE_UART_NUM), CONFIG_ESP_CONSOLE_UART_BAUDRATE);
 #endif


### PR DESCRIPTION
The UART clock frequency is wrong for esp32, as a result the UART does not print properly on this example.