### PR TITLE
fix: correct markdown formatting for formula

### DIFF
--- a/docs/en/OFDM-introduction.md
+++ b/docs/en/OFDM-introduction.md
@@ -50,7 +50,7 @@ Using this method, the receiver can independently decode each sub-signal $a$ and
 
 Taking $\sin(\omega_1 t)$ and $\sin(\omega_2 t)$ as examples, we demonstrate the transition from intuitive to abstract. The simple orthogonal model is the foundation of all complex theories.
 
-Next, expand the model of $\sin(t)$ and $\sin(2t)$ to more subcarrier sequences $\{ \sin(2T \Delta f \cdot t), \sin(2T \Delta f \cdot 2t), \sin(2T \Delta f \cdot 3t), \ldots, \sin(2T \Delta f \cdot kt) \} $ (e.g., $k=16, 256, 1024$), where $2\pi$ is a constant, $\Delta f $ is the preselected carrier frequency interval, $T$ is the period, and $k$ is the maximum index of the sequence.
+Next, expand the model of $\sin(t)$ and $\sin(2t)$ to more subcarrier sequences $\{ \sin(2T \Delta f \cdot t), \sin(2T \Delta f \cdot 2t), \sin(2T \Delta f \cdot 3t), \ldots, \sin(2T \Delta f \cdot kt) \}$ (e.g., $k=16, 256, 1024$), where $2\pi$ is a constant, $\Delta f$ is the preselected carrier frequency interval, $T$ is the period, and $k$ is the maximum index of the sequence.
 
 The orthogonality of multiple functions is based on their pairwise orthogonality. If a set of functions $\{f_1(t), f_2(t), ..., f_n(t)\}$ is pairwise orthogonal over an interval, then for any $i \ne j$:
 $\int_{a}^{b} f_{i}(t) f_{j}(t) dt = 0$


### PR DESCRIPTION
## Description

- Removed whitespace to correctly render formula

| Before | After |
| --- | --- | 
|<img width="1042" height="95" alt="before" src="https://github.com/user-attachments/assets/24157d20-4ae9-4e26-883e-1a9bc14daf74" /> | <img width="880" height="96" alt="after" src="https://github.com/user-attachments/assets/dc97a319-0b55-4c84-80f7-695490085265" /> | 

Before submitting a Pull Request, please ensure the following:

- [x ] 🚨 This PR does not introduce breaking changes.
- [x] All CI checks (GH Actions) pass.
- [x] Documentation is updated as needed.
- [x] Tests are updated or added as necessary.
- [x] Code is well-commented, especially in complex areas.
- [x] Git history is clean — commits are squashed to the minimum necessary.
